### PR TITLE
RDO-1967: Always install Java using the java-role on Jenkins nodes

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 dependencies:
   - role: devops.repos
+  - role: devops.java
   - role: devops.common
   - role: devops.vault-token


### PR DESCRIPTION
In the past Java packages were installed in different ways on Jenkins nodes. Now the java-role should always be used for installing Java for consistency and simplicity.